### PR TITLE
Fixed response pack values array

### DIFF
--- a/dist/device.js
+++ b/dist/device.js
@@ -167,7 +167,7 @@ class Device {
         break;
       case "res": // command response
         pack.opt.forEach((col, i) => {
-          this.status[col] = pack.val[i];
+          this.status[col] = pack.p[i];
         });
         this.log.debug(`[${this.mac}] Command responded: %j`, this.status);
         this.updateCallback();


### PR DESCRIPTION
On changing some settings we receive an error:
`TypeError: Cannot read property '0' of undefined`
This patch fixes invalid array property
fixes https://github.com/Elethom/homebridge-gree-heatercooler-v2/issues/21